### PR TITLE
Add support for theming and custom elements styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 import domElements from './lib/utils/domElements'
 import createElement from './lib/create-element'
+import { ThemeContext } from './lib/create-provider'
 
-const styled = {}
+// styled custom components
+function styled(el) {
+  return createElement(el)
+}
 
 for (const tag of domElements) {
   styled[tag] = createElement(tag)
 }
 
+export const ThemeProvider = ThemeContext.Provider;
 export default styled

--- a/lib/create-element.js
+++ b/lib/create-element.js
@@ -1,19 +1,27 @@
+import { h } from '@stencil/core';
 import { injectStyles }  from './inject-styles'
 import hash from './utils/hash'
 import generateAlphabeticName from './utils/generateAlphabeticName'
+import { ThemeContext } from "./create-provider";
 
 let counter = 0
-
 export default (Tag) =>
   (strings, ...values) => {
-    
     return (props, children) => {
       // generate a unique component ID
       counter++
       const componentId = 'sc-' + generateAlphabeticName(hash('sc' + counter))
-  
-      // inject styles into stylesheet 
-      injectStyles(componentId, strings, props, values)
-      return h(Tag, { class: componentId, ref: (props && props.ref) }, children)
+      
+      // consume and generate styles
+      return h(ThemeContext.Consumer, {}, (theme) => {
+        // inject styles into stylesheet 
+        injectStyles(componentId, strings, {...props, theme}, values)
+
+        return h(Tag, { 
+          ...props, 
+          class: [props.class, componentId].filter(x => !!x).join(' '), 
+          ref: (props && props.ref) 
+        }, children)
+      })
     }
   }

--- a/lib/create-element.js
+++ b/lib/create-element.js
@@ -10,7 +10,7 @@ export default (Tag) =>
     return (props, children) => {
       // generate a unique component ID
       counter++
-      const componentId = 'sc-' + generateAlphabeticName(hash('sc' + counter))
+      const componentId = 'ssc-' + generateAlphabeticName(hash('ssc' + counter))
       
       // consume and generate styles
       return h(ThemeContext.Consumer, {}, (theme) => {

--- a/lib/create-provider.js
+++ b/lib/create-provider.js
@@ -1,0 +1,18 @@
+let context = {};
+let listeners = {};
+export const ThemeContext = {
+  Provider: function(props, children) {
+    context = props.theme
+    
+    for (const fn of Object.values(listeners)) {
+      fn(context)
+    }
+    
+    return [children]
+  },
+  Consumer: function({ key }, [renderer]) {
+    listeners[key] = renderer
+    
+    return renderer(context)
+  }
+};

--- a/lib/inject-styles.js
+++ b/lib/inject-styles.js
@@ -1,8 +1,10 @@
-import stylis from './vendor/stylis/stylis.min'
+import './vendor/stylis/stylis.min'
 
 // create a <style> tag which will hold all our component styles
 const sheet = document.createElement('style')
 document.head.appendChild(sheet)
+
+const styleCache = {}
 
 /**
  * Parses an array of strings from a template string into an object.
@@ -23,7 +25,15 @@ export const injectStyles = (componentId, strings, props = {}, funcs) => {
     return acc + cur + ((funcs[i] && typeof funcs[i] === 'function') ? funcs[i](props) : (funcs[i] || ''))
   }, '')
 
+  // clear style if exists
+  if (styleCache[componentId] != null) {
+    sheet.innerHTML = sheet.innerHTML.replace(styleCache[componentId], '')
+  }
+
   // parse the rule with stylis and add to our <style> tag
   const rule = stylis('html /deep/ .' + componentId, css)
   sheet.innerHTML += rule
+
+  // save in cache last style
+  styleCache[componentId] = rule
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "jest": "^23.6.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "@stencil/core": "^1.1.7"
+  }
 }


### PR DESCRIPTION
This pull-request have two main goals: 

- Add theme support
- Add support for custom elements 

### The theme support feature

The theme provider feature can't be implemented using StateTunnel, the use inside the <context-consumer> component (created by state-tunnel lib) not work as expect, I think that some more hardless modifications would have to be made.

#### Usage of Theme
Limitation: cannot be used in components with **shadow** option enabled. (Need improvement)

```javascript
// app.tsx
import styled, { ThemeProvider }  from 'stencil-styled-components';

const Button = styled.button`
    background: ${props => props.theme.bg};
`;

@Component({
    tag: 'my-app'
})
export class App {
    render() {
        return (
            <ThemeProvider theme={{ bg: 'red' }}>
                <Button>Hello themed button!</Button>
            </ThemeProvider>
        );
    }
}
```

### Allow styling support for custom-components
I make small modification for allow the styling for all components (Custom or Functional).

#### Usage

```javascript
// my-button.tsx
import { Host, h } from '@stencil/core';
import styled  from 'stencil-styled-components';

const CustomHost = styled(Host)`
    background: red;
`;

const CustomStyledComponent = styled('custom-component')`
    background: red;
`;

@Component({
    tag: 'my-button'
})
export class MyButton {
    render() {
        return (
            <CustomHost>
                <CustomStyledComponent>
                    <slot />
                </CustomStyledComponent>
            </CustomHost>
        );
    }
}
```

### Bonus
Implement styleCache for prevent mult css rule. (Need to be improved, 
it is possible to intelligently separate rules to prevent repaint of the entire application)