### PR TITLE
Added note about ShadowDOM components

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Small library to bring the concept of [styled-components](https://github.com/styled-components/styled-components) to StencilJS.
 
+> Works only on [Scoped components](https://stenciljs.com/docs/styling#scoped-css), Shadow DOM isn't supported.
+
 ## Installation
 
 ```


### PR DESCRIPTION
Hey, what's up? 

I added a note about Shadow DOM components. Currently works only on scoped components. This note will facilitate to future users.